### PR TITLE
TE-2192 handleErrors returns any status code when response is not ok

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,8 @@
 const ACCEPT = 'Accept';
 const CONTENT_TYPE = 'Content-Type';
-const APPLICATION_JSON = 'application/json';
+
+export const APPLICATION_JSON = 'application/json';
+export const TEXT_PLAIN = 'text/plain';
 
 export const GET = 'GET';
 

--- a/src/utils/getParsedBody.js
+++ b/src/utils/getParsedBody.js
@@ -1,0 +1,20 @@
+import { get } from 'lodash';
+
+import { TEXT_PLAIN, APPLICATION_JSON } from '../constants';
+
+import { parseTextResponse } from './parseTextResponse';
+import { parseJSONResponse } from './parseJSONResponse';
+
+/**
+ * @param  {Object} response
+ * @return {Promise}
+ */
+export const getParsedBody = response => {
+  const contentType = get(response, ['headers', '_headers', 'content-type'])[0];
+
+  if (contentType === TEXT_PLAIN) return parseTextResponse(response);
+
+  if (contentType === APPLICATION_JSON) return parseJSONResponse(response);
+
+  return Promise.resolve('');
+};

--- a/src/utils/getParsedBody.spec.js
+++ b/src/utils/getParsedBody.spec.js
@@ -1,0 +1,59 @@
+jest.mock('lodash');
+jest.mock('./parseTextResponse');
+jest.mock('./parseJSONResponse');
+
+import { get } from 'lodash';
+
+import { TEXT_PLAIN, APPLICATION_JSON } from '../constants';
+
+import { getParsedBody } from './getParsedBody';
+import { parseTextResponse } from './parseTextResponse';
+import { parseJSONResponse } from './parseJSONResponse';
+
+Promise.resolve = jest.fn(() => Promise);
+
+const response = {
+  headers: {
+    _headers: {
+      'content-type': ['seren/dipity'],
+    },
+  },
+};
+
+describe('`getParsedBody`', () => {
+  it('it should call `get` with the right arguments', () => {
+    get.mockReturnValueOnce('ver/mut');
+    getParsedBody(response);
+
+    expect(get).toHaveBeenCalledWith(response, [
+      'headers',
+      '_headers',
+      'content-type',
+    ]);
+  });
+
+  describe('if `content-type` is set to `plain/text`', () => {
+    it('should call `parseTextResponse` with the right argument', () => {
+      get.mockReturnValueOnce(TEXT_PLAIN);
+      getParsedBody(response);
+
+      expect(parseTextResponse).toHaveBeenCalledWith(response);
+    });
+  });
+
+  describe('if `content-type` is set to `application/json`', () => {
+    it('should call `parseJSONResponse` with the right argument', () => {
+      get.mockReturnValueOnce(APPLICATION_JSON);
+      getParsedBody(response);
+
+      expect(parseJSONResponse).toHaveBeenCalledWith(response);
+    });
+  });
+
+  it('should return `Promise.resolve` with an empty string', () => {
+    get.mockReturnValueOnce('com/plain');
+    const actual = getParsedBody(response);
+
+    expect(actual).toBe(Promise);
+  });
+});

--- a/src/utils/handleErrors.js
+++ b/src/utils/handleErrors.js
@@ -1,3 +1,5 @@
+import { getParsedBody } from './getParsedBody';
+
 /**
  * Helper for throwing Error if response to fetch is not ok
  * @param  {Object} response
@@ -6,11 +8,33 @@
  */
 export const handleErrors = response => {
   if (!response.ok) {
-    if (response.status >= 500) {
+    const { status, statusText, url } = response;
+    const error = new Error(status);
+
+    getParsedBody(response).then(parsedBody => {
+      const body = JSON.stringify(parsedBody, null, ' ');
+
       // eslint-disable-next-line no-console
-      console.error(response);
-    }
-    throw Error(response.statusText);
+      console.log(`
+
+       ██████╗ ██╗  ██╗    ███╗   ██╗ ██████╗ 
+      ██╔═══██╗██║  ██║    ████╗  ██║██╔═══██╗
+      ██║   ██║███████║    ██╔██╗ ██║██║   ██║
+      ██║   ██║██╔══██║    ██║╚██╗██║██║   ██║
+      ╚██████╔╝██║  ██║    ██║ ╚████║╚██████╔╝
+       ╚═════╝ ╚═╝  ╚═╝    ╚═╝  ╚═══╝ ╚═════╝ 
+                        
+        This sucks... 
+       
+        Request to ${url} failed.
+        Status code: ${status}
+        Status text: ${statusText}
+        Body: ${body}
+      `);
+    });
+
+    throw error;
   }
+
   return response;
 };

--- a/src/utils/handleErrors.spec.js
+++ b/src/utils/handleErrors.spec.js
@@ -1,32 +1,92 @@
+jest.mock('./getParsedBody');
+
 import { handleErrors } from './handleErrors';
+import { getParsedBody } from './getParsedBody';
+
+const response = {
+  ok: false,
+  url: 'sombala',
+  status: '9999',
+  statusText: 'the end',
+  body: { letTheBodies: 'hit the floor' },
+  headers: {
+    _headers: {
+      'content-type': ['seren/dipity'],
+    },
+  },
+};
+
+const { body, status, statusText, url } = response;
+
+const errorMessage = `
+           
+ This sucks... 
+
+ Request to ${url} failed.
+ Status code: ${status}
+ Status text: ${statusText}
+ Body: ${body}
+`;
+
+JSON.stringify = jest.fn(() => 'BIP, BOOP, BURI, ICH...');
+// eslint-disable-next-line no-console
+console.log = jest.fn();
+
+getParsedBody.mockImplementation(() => getParsedBody);
+getParsedBody.then = jest.fn();
+
+getParsedBody.then.mockImplementation(callback => {
+  callback(response);
+  JSON.stringify;
+  // eslint-disable-next-line no-console
+  console.log(errorMessage);
+  return getParsedBody;
+});
+getParsedBody.firstThenArg = response;
 
 describe('handleErrors', () => {
-  it('should throw and Error if the response is not ok', () => {
-    const message = 'Blaaargh';
-
-    expect(() => {
-      handleErrors({ ok: false, statusText: message });
-    }).toThrowError(message);
-  });
-
-  it('should return the response if the response is ok', () => {
-    const okResponse = { ok: true };
-    const actual = handleErrors(okResponse);
-
-    expect(actual).toBe(okResponse);
-  });
-
-  it('if received a server error then it should log the error', () => {
-    const response = { ok: false, statusText: 'Blaaargh', status: 505 };
-
-    // eslint-disable-next-line no-console
-    console.error = jest.fn();
-
-    expect(() => {
+  beforeAll(() => {
+    try {
       handleErrors(response);
-    }).toThrowError(response.statusText);
+    } catch (error) {}
+  });
 
-    // eslint-disable-next-line no-console
-    expect(console.error).toHaveBeenCalledWith(response);
+  describe('if response is ok', () => {
+    it('should return the response', () => {
+      const okResponse = { ok: true };
+      const actual = handleErrors(okResponse);
+
+      expect(actual).toBe(okResponse);
+    });
+  });
+
+  describe('if response is not ok', () => {
+    it('should call `getParsedBody` with the right argument', () => {
+      expect(getParsedBody).toHaveBeenCalledWith(response);
+    });
+    describe('`getParsedBody`', () => {
+      it('should call `getParsedBody.then` the first time with a function', () => {
+        expect(getParsedBody.then).toHaveBeenCalledWith(expect.any(Function));
+      });
+
+      describe('the function passed to  `getParsedBody.then`', () => {
+        it('should call `JSON.stringify` with the right argument', () => {
+          expect(JSON.stringify).toHaveBeenCalledWith(response, null, ' ');
+        });
+
+        it('should log the `status`, `statusText`, `url` and `body` of the response', () => {
+          // eslint-disable-next-line no-console
+          expect(console.log).toHaveBeenCalledWith(
+            expect.stringContaining(errorMessage)
+          );
+        });
+      });
+
+      it('should throw and Error', () => {
+        expect(() => {
+          handleErrors(response);
+        }).toThrowError(status);
+      });
+    });
   });
 });


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2192)

### What **one** thing does this PR do?
Allows handle errors to return any `statusCode` when the response is not ok.


### Log text/plain
![text:plain](https://user-images.githubusercontent.com/33876435/57538179-22313300-7348-11e9-9d2b-d4030259cc2f.gif)

### Log application/json
![json](https://user-images.githubusercontent.com/33876435/57538185-28271400-7348-11e9-8859-b4ae5d5dbbb6.gif)
